### PR TITLE
Add a auto-acquire-permissions feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ license = "MIT OR Apache-2.0"
 
 repository = "https://github.com/positiveway/mouse-keyboard-input"
 
+[features]
+default=["auto-acquire-permissions"]
+auto-acquire-permissions=[]
+
 [dependencies]
 crossbeam-channel ="0.5"
 libc = "0.2"

--- a/src/virtual_device.rs
+++ b/src/virtual_device.rs
@@ -73,11 +73,14 @@ impl VirtualDevice {
             .custom_flags(libc::O_NONBLOCK)
             .open(path)?;
 
-        use std::os::unix::fs::PermissionsExt;
+        #[cfg(feature = "auto-acquire-permissions")]
+        {
+            use std::os::unix::fs::PermissionsExt;
 
-        let metadata = file.metadata()?;
-        let mut permissions = metadata.permissions();
-        permissions.set_mode(0o660);
+            let metadata = file.metadata()?;
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o660);
+        }
 
         // let usb_device = input_id {
         //     bustype: 0x03,


### PR DESCRIPTION
Add a auto-acquire-permissions feature gate to make permission change optional.
It might not the best choice to modify any file permission without a notation.